### PR TITLE
Add Mermaid Diagram support

### DIFF
--- a/docs/mermaid.md
+++ b/docs/mermaid.md
@@ -1,0 +1,132 @@
+# Mermaid
+
+Mermaid is a JavaScript based diagramming and charting tool that renders
+Markdown-inspired text definitions to create and modify diagrams dynamically.
+
+This page includes Mermaid example diagrams.
+
+## Class Diagram
+
+``` mermaid
+classDiagram
+  Person <|-- Student
+  Person <|-- Professor
+  Person : +String name
+  Person : +String phoneNumber
+  Person : +String emailAddress
+  Person: +purchaseParkingPass()
+  Address "1" <-- "0..1" Person:lives at
+  class Student{
+    +int studentNumber
+    +int averageMark
+    +isEligibleToEnrol()
+    +getSeminarsTaken()
+  }
+  class Professor{
+    +int salary
+  }
+  class Address{
+    +String street
+    +String city
+    +String state
+    +int postalCode
+    +String country
+    -validate()
+    +outputAsLabel()
+  }
+```
+
+## Entity Relationship Diagram
+
+``` mermaid
+erDiagram
+  CUSTOMER }|..|{ DELIVERY-ADDRESS : has
+  CUSTOMER ||--o{ ORDER : places
+  CUSTOMER ||--o{ INVOICE : "liable for"
+  DELIVERY-ADDRESS ||--o{ ORDER : receives
+  INVOICE ||--|{ ORDER : covers
+  ORDER ||--|{ ORDER-ITEM : includes
+  PRODUCT-CATEGORY ||--|{ PRODUCT : contains
+  PRODUCT ||--o{ ORDER-ITEM : "ordered in"
+```
+
+## Flow Chart
+
+``` mermaid
+graph LR
+  A[Start] --> B{Error?};
+  B -->|Yes| C[Hmm...];
+  C --> D[Debug];
+  D --> B;
+  B ---->|No| E[Yay!];
+```
+
+## Gaant Diagram
+
+``` mermaid
+gantt
+  dateFormat  YYYY-MM-DD
+  title Adding GANTT diagram to mermaid
+  excludes weekdays 2014-01-10
+
+  section A section
+  Completed task            :done,    des1, 2014-01-06,2014-01-08
+  Active task               :active,  des2, 2014-01-09, 3d
+  Future task               :         des3, after des2, 5d
+  Future task2              :         des4, after des3, 5d
+```
+
+## GitGraph Diagram
+
+``` mermaid
+gitGraph
+  commit
+  commit
+  branch develop
+  checkout develop
+  commit
+  commit
+  checkout main
+  merge develop
+  commit
+  commit
+```
+
+## Pie Chart
+
+``` mermaid
+pie title Pets adopted by volunteers
+  "Dogs" : 386
+  "Cats" : 85
+  "Rats" : 15
+```
+
+## Sequence Diagram
+
+``` mermaid
+sequenceDiagram
+  Alice->>John: Hello John, how are you?
+  loop Healthcheck
+      John->>John: Fight against hypochondria
+  end
+  Note right of John: Rational thoughts!
+  John-->>Alice: Great!
+  John->>Bob: How about you?
+  Bob-->>John: Jolly good!
+```
+
+## State Diagram
+
+``` mermaid
+stateDiagram-v2
+  state fork_state <<fork>>
+    [*] --> fork_state
+    fork_state --> State2
+    fork_state --> State3
+
+    state join_state <<join>>
+    State2 --> join_state
+    State3 --> join_state
+    join_state --> State4
+    State4 --> [*]
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,3 +114,5 @@ nav:
 
   - Ruby:
     - Subprocesses: ruby/subprocesses.md
+
+  - Mermaid: mermaid.md

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "lint": "markdownlint-cli2 '**/*.md' '!node_modules'",
-    "serve": "markdownlint-cli2 '**/*.md' '!node_modules' && mkdocs serve"
+    "serve": "markdownlint-cli2 '**/*.md' '!node_modules' && mkdocs serve",
+    "install-mkdocs-extensions": "pip3 install mkdocs pymdown-extensions mkdocs-material markdown-include"
   },
   "devDependencies": {
     "markdownlint-cli2": "^0.5.1"


### PR DESCRIPTION
Add [Mermaid Diagram](https://mermaid.js.org) support to this project.

Add a page of Mermaid examples.

Add an npm script in `package.json` to install mkdocs and all dependencies needed to run this project locally.