### PR TITLE
Upgrade mkdocs-material to get latest Mermaid library

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,13 +14,6 @@ extra:
     doc_owner_shortid: jcouball
     doc_owner_email: jcouball@yahoo.com
 
-extra_css:
-    - css/mermaid_local.css
-
-extra_javascript:
-    - js/mermaid.js
-    - js/mermaid_settings.js
-
 markdown_extensions:
     - admonition
     - attr_list

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs
 pymdown-extensions
-mkdocs-material
+mkdocs-material ~= 9.0, >= 9.0.3
 markdown-include


### PR DESCRIPTION
Require mkdocs-material 9.0.3 so mermaid is upgraded from 9.1.7 to 9.3.0.

Mermaid release notes:
https://github.com/mermaid-js/mermaid/releases

Also remove unneeded Mermaid `extra_css` and `extra_javascript` entries.