### PR TITLE
Document local dev setup and available `npm run` scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # My Personal Tech Docs
 
 [My notes hosted on GitHub Pages](https://jcouball.github.io/notes)
+
+## Getting Started
+
+It is assumed that you have node and python installed and in the path.
+
+In this project's root directory run `npm run setup` to install the required node and
+python packages to lint, build, and serve the documentation.
+
+## Available Scripts
+
+The following scripts are available via `npm run`:
+
+* `npm run setup`: install required node and python packages for markdownlint and
+  mkdocs
+* `npm run lint`: run the markdown linter configured by `.markdownlint.yml`
+* `npm run build`: run the markdown linter and build the mkdocs site
+* `npm run serve`: run the markdown linter, build the mkdocs site, and serve the site
+  for testing

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "scripts": {
+    "setup": "npm install && pip3 install -r requirements.txt",
     "lint": "markdownlint-cli2 '**/*.md' '!node_modules'",
-    "serve": "markdownlint-cli2 '**/*.md' '!node_modules' && mkdocs serve",
-    "install-mkdocs": "pip3 install -r requirements.txt"
+    "build": "markdownlint-cli2 '**/*.md' '!node_modules' && mkdocs build",
+    "serve": "markdownlint-cli2 '**/*.md' '!node_modules' && mkdocs serve"
   },
   "devDependencies": {
-    "markdownlint-cli2": "^0.5.1"
+    "markdownlint-cli2": "^0.11.0"
   }
 }


### PR DESCRIPTION
In an effort to make conntributions easier, document local development setup and available `npm run` scripts in the README.md

The available `npm run` scripts were refactored as follows:
* `npm run setup`: install required node and python packages for markdownlint and
  mkdocs
* `npm run lint`: run the markdown linter configured by `.markdownlint.yml`
* `npm run build`: run the markdown linter and build the mkdocs site
* `npm run serve`: run the markdown linter, build the mkdocs site, and serve the site
  for testing