### PR TITLE
fix: correct variables passed to the deploy action

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -46,7 +46,4 @@ jobs:
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CUSTOM_DOMAIN: optionaldomain.com
-          CONFIG_FILE: mkdocs.yml
-          EXTRA_PACKAGES: build-base
           REQUIREMENTS: requirements.txt


### PR DESCRIPTION
Due to a copy and paste error, the deploy action was setting a custom domain that did not exist. Fix the environment variables passed to the deploy action so the docs work.