### PR TITLE
feat: make it easy to run the mkdocs server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+      {
+          "name": "Run npm serve",
+          "type": "node",
+          "request": "launch",
+          "program": "${workspaceFolder}/node_modules/.bin/npm",
+          "args": ["run", "serve"],
+          "console": "integratedTerminal",
+          "internalConsoleOptions": "neverOpen"
+      }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+      {
+          "label": "Run the mkdocs server",
+          "type": "shell",
+          "command": "npm run serve",
+          "group": {
+              "kind": "build",
+              "isDefault": true
+          },
+          "problemMatcher": []
+      }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "serve": "markdownlint-cli2 '**/*.md' '!node_modules' && mkdocs serve"
   },
   "devDependencies": {
-    "markdownlint-cli2": "^0.14.0"
+    "markdownlint-cli2": "^0.14.0",
+    "npm": "^10.9.2"
   }
 }


### PR DESCRIPTION
This launch.json defines a launch configuration that
launches a debugging session in VS Code to run the npm
run serve script using the local npm binary, with output
displayed in the integrated terminal.

This tasks.json file defines a default build task in VS Code
to execute the npm run serve command as a shell script,
which can be triggered manually or via the default build
task shortcut.