### PR TITLE
fix: make tab size for markdown files 4 spaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,7 @@
           "!.yardopts"
         ],
         "rewrap.wrappingColumn": 85,
+        "terminal.integrated.shell.linux": "/bin/bash",
         "workbench.iconTheme": "vscode-icons"
       },
       "extensions": [
@@ -32,6 +33,8 @@
         "GitHub.copilot",
         "GitHub.copilot-chat",
         "stkb.rewrap",
+        "ms-python.python",
+        "ms-vscode.node-debug2",
         "yzhang.markdown-all-in-one"
       ]
     }

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,7 +1,7 @@
 default: true
 
 # Unordered list indentation
-MD007: { indent: 2 }
+MD007: { indent: 4 }
 
 # Line length
 MD013: { line_length: 90, tables: false, code_blocks: false }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.detectIndentation": false,
+  "[markdown]":{
+    "editor.tabSize": 4
+  },
+  "markdown.extension.list.indentationSize": "inherit"
+}

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ These are my personal notes I have taken on many different technical and musical
 subjects.
 
 * [Getting Started](#getting-started)
-  * [Without a devcontainer](#without-a-devcontainer)
-  * [In VS Code](#in-vs-code)
-  * [Deploying](#deploying)
+    * [Without a devcontainer](#without-a-devcontainer)
+    * [In VS Code](#in-vs-code)
+    * [Deploying](#deploying)
 
 ## Getting Started
 
@@ -50,8 +50,8 @@ The deployment is configured with these files:
 * config/provision.yaml: Proxmox provisioning configuration
 * Dockerfile: creates the production deployment image which is deployed to docker hub
   to [jcouball/notes](https://hub.docker.com/repository/docker/jcouball/notes/general)
-  * docker-build: a script to build the docker image locally
-  * docker-run: a script to run the docker image locally
+    * docker-build: a script to build the docker image locally
+    * docker-run: a script to run the docker image locally
 * config/deploy.yaml: Kamal 2 deployment configuration
 
 Currently, Proxmox configuration must be done manaully (see the commands at the

--- a/docs/ai/getting_started_on_prompt_engineering.md
+++ b/docs/ai/getting_started_on_prompt_engineering.md
@@ -402,12 +402,12 @@ Focusing on metrics humans can look at and evaluate.
 Three objective metrics:
 
 * **Accuracy**:
-  * **Factual correctness**: the model answers with actual facts
-  * **Semantic correctness**: does it answer the question we ask
+    * **Factual correctness**: the model answers with actual facts
+    * **Semantic correctness**: does it answer the question we ask
 * **Speed**
-  * Processing speed: how long the answer takes to generate
-  * Response speed: how long it takes a user to receive a response (includes
-    network latency and other delays)
+    * Processing speed: how long the answer takes to generate
+    * Response speed: how long it takes a user to receive a response (includes
+        network latency and other delays)
 * **Relevancy**: is the answer relevant to the question we ask
 
 ### Subjective Metrics
@@ -422,23 +422,23 @@ Human opinions on coherence, tone, and clarity.
 ### Evaluation Techniques
 
 * Surveys and interviews
-  * Did the AI understand your prompt correctly?
-  * Was the response AI gave relevant to your prompt?
-  * Was the AI's response easy to understand?
-  * Did the AI provide a complete answer to your prompt, or did it miss anything?
-  * Did you find the Al's response helpful?
-  * Was the Al's response delivered in an appropriate tone?
-  * How satisfied are you with the speed of the Al's response?
-  * Did you feel the conversation with the Al flowed naturally?
+    * Did the AI understand your prompt correctly?
+    * Was the response AI gave relevant to your prompt?
+    * Was the AI's response easy to understand?
+    * Did the AI provide a complete answer to your prompt, or did it miss anything?
+    * Did you find the Al's response helpful?
+    * Was the Al's response delivered in an appropriate tone?
+    * How satisfied are you with the speed of the Al's response?
+    * Did you feel the conversation with the Al flowed naturally?
 
 * A/B Testing
-  * Example given for a customer service bot
-  * Use two different prompts to get the conversation started
-  * Which prompt led to more successful return transactions?
-  * Which prompt resulted in shorter conversation lengths (indicating possibly
-    smoother interactions)?
-  * *Which prompt received higher customer satisfaction scores in post-interaction
-    surveys?
+    * Example given for a customer service bot
+    * Use two different prompts to get the conversation started
+    * Which prompt led to more successful return transactions?
+    * Which prompt resulted in shorter conversation lengths (indicating possibly
+        smoother interactions)?
+    * *Which prompt received higher customer satisfaction scores in post-interaction
+        surveys?
 
 * The [OpenAI API Fine tuning
   guide](https://platform.openai.com/docs/guides/fine-tuning) can give further help
@@ -470,14 +470,14 @@ use. This is similar but different than temperature.
 #### Objective Metrics
 
 1. **Accuracy**:
-   * *Factual correctness*: Ensuring the model provides factually accurate
-     information.
-   * *Semantic correctness*: Assessing if the model's response is relevant to the
-     posed question.
+    * *Factual correctness*: Ensuring the model provides factually accurate
+        information.
+    * *Semantic correctness*: Assessing if the model's response is relevant to the
+        posed question.
 2. **Speed**:
-   * *Processing speed*: Time taken for the model to generate a response.
-   * *Response speed*: Total time for the user to receive a response, including
-     potential delays like network latency.
+    * *Processing speed*: Time taken for the model to generate a response.
+    * *Response speed*: Total time for the user to receive a response, including
+        potential delays like network latency.
 3. **Relevancy**: Evaluating if the model's response is pertinent to the question
    asked.
 
@@ -493,9 +493,9 @@ use. This is similar but different than temperature.
 * **Surveys and Interviews**: Questions about understanding, relevance, clarity,
   completeness, helpfulness, tone, response speed, and natural conversation flow.
 * **A/B Testing**:
-  * Example: Customer service bot interaction.
-  * Comparing different prompts for effectiveness in real-world scenarios.
-  * Metrics: Transaction success, conversation length, and customer satisfaction.
+    * Example: Customer service bot interaction.
+    * Comparing different prompts for effectiveness in real-world scenarios.
+    * Metrics: Transaction success, conversation length, and customer satisfaction.
 
 ### Example: Getting Better Results by Adjusting Parameters Summarized
 

--- a/docs/git/git.md
+++ b/docs/git/git.md
@@ -29,12 +29,12 @@
 * [Number of commits in a feature branch](#number-of-commits-in-a-feature-branch)
 * [What does HEAD point to?](#what-does-head-point-to)
 * [Ways to determine the current branch](#ways-to-determine-the-current-branch)
-  * [Current branch states](#current-branch-states)
-    * [1. Branch Exists](#1-branch-exists)
-    * [2. Unborn Branch](#2-unborn-branch)
-    * [3. Detached HEAD](#3-detached-head)
-  * [Commands to determine HEAD branch state](#commands-to-determine-head-branch-state)
-  * [Commands to determine the current branch](#commands-to-determine-the-current-branch)
+    * [Current branch states](#current-branch-states)
+        * [1. Branch Exists](#1-branch-exists)
+        * [2. Unborn Branch](#2-unborn-branch)
+        * [3. Detached HEAD](#3-detached-head)
+    * [Commands to determine HEAD branch state](#commands-to-determine-head-branch-state)
+    * [Commands to determine the current branch](#commands-to-determine-the-current-branch)
 
 ## Building git from source
 
@@ -238,31 +238,31 @@ Amend older commit messages:
 ## Stash
 
 * `git stash`
-  * [save “message”] - annotate a stash with a description
-  * [--include-untracked | -u] - include untracked files
-  * [--all | -a] - include ignored files
-  * [—patch | -p] - interactively choose which change hunks to save in the stash.
-      Press ‘?’ for a list of hunk commands.
+    * [save “message”] - annotate a stash with a description
+    * [--include-untracked | -u] - include untracked files
+    * [--all | -a] - include ignored files
+    * [—patch | -p] - interactively choose which change hunks to save in the stash.
+        Press ‘?’ for a list of hunk commands.
 * `git stash apply`
-  * re-apply a stash but keep the stash
+    * re-apply a stash but keep the stash
 * `git stash pop`
-  * re-apply the most recently created stash: stash@{0}
-  * [identifier] - re-apply a stash by identifier (see git stash list)
+    * re-apply the most recently created stash: stash@{0}
+    * [identifier] - re-apply a stash by identifier (see git stash list)
 * `git stash list`
-  * List all available stashes with identifier and message
+    * List all available stashes with identifier and message
 * `git stash show`
-  * View a summary of the last stash
-  * [identifier] - show the summary of a different stash
-  * [--patch | -p] - include a full diff of the stash
+    * View a summary of the last stash
+    * [identifier] - show the summary of a different stash
+    * [--patch | -p] - include a full diff of the stash
 * `git stash branch [branch-name]`
-  * check out a new branch based on the commit the last stash was created from and
-    then pops that stash’s changes onto it
-  * [identifier] - branch and pop from a different stash
+    * check out a new branch based on the commit the last stash was created from and
+        then pops that stash’s changes onto it
+    * [identifier] - branch and pop from a different stash
 * `git stash drop`
-  * Delete the last stash
-  * [identifier] - delete a different stash
+    * Delete the last stash
+    * [identifier] - delete a different stash
 * `git stash clean`
-  * Delete all stashes
+    * Delete all stashes
 
 ## Checkout a pull request
 

--- a/docs/javascript/complete_node_js/02_node_module_system.md
+++ b/docs/javascript/complete_node_js/02_node_module_system.md
@@ -581,15 +581,15 @@ console.log('Listening on port 3000...');
 In this section, I learned:
 
 * In Node:
-  * the `window` object does not exist
-  * The global object in Node is `global`
-  * Variables define are not global
+    * the `window` object does not exist
+    * The global object in Node is `global`
+    * Variables defined are not global
 
 * Every file in a Node application is a module
-  * Node automatically wraps the code in each file with an IIFE (Immediately-invoked
-    Function Expression) to create scope.
-  * Variables and functions defined in one file are only scoped to that file and not
-    visible to other files unless explicitly exported.
+    * Node automatically wraps the code in each file with an IIFE (Immediately-invoked
+        Function Expression) to create scope.
+    * Variables and functions defined in one file are only scoped to that file and not
+        visible to other files unless explicitly exported.
 
 * To export a variable or function from a module, you need to add them to
   `module.exports`:
@@ -606,8 +606,8 @@ In this section, I learned:
 
 * EventEmitter is one of the core classes in Node that allows us to raise (emit) and
   handle events.
-  * Several built-in classes in Node derive from EventEmitter.
+    * Several built-in classes in Node derive from EventEmitter.
 
-  * To create a class with the ability to raise events, we should extend EventEmitter:
+    * To create a class with the ability to raise events, we should extend EventEmitter:
 
-      `class Logger extends EventEmitter { }`
+        `class Logger extends EventEmitter { }`

--- a/docs/javascript/complete_node_js/03_node_package_manager.md
+++ b/docs/javascript/complete_node_js/03_node_package_manager.md
@@ -152,10 +152,10 @@ If the module is a path that begins with './', '.', or '../', node will do the f
 * **If a file with the given name exists** (or the given name plus the extensions .js,
   .json, or .node exists), Node will load that file
 * **If a directory with the given name exists**:
-  * And that directory contains a file named `package.json`, Node will try to load
-    the file named in the `main` property.
-  * And that directory contains a file named `index.js` or `index.node`, Node will
-    load that file.
+    * And that directory contains a file named `package.json`, Node will try to load
+        the file named in the `main` property.
+    * And that directory contains a file named `index.js` or `index.node`, Node will
+        load that file.
 * **Otherwise**, Node will throw a `MODULE_NOT_FOUND` error
 
 ### Core Modules
@@ -206,10 +206,10 @@ To find the file to include, Node will check for the following in each path:
 * **If a file with the given name exists** (or the given name plus the extensions .js,
   .json, or .node exists), Node will load that file
 * **If a directory with the given name exists**:
-  * And that directory contains a file named `package.json`, Node will try to load
-    the file named in the `main` property.
-  * And that directory contains a file named `index.js` or `index.node`, Node will
-    load that file.
+    * And that directory contains a file named `package.json`, Node will try to load
+        the file named in the `main` property.
+    * And that directory contains a file named `index.js` or `index.node`, Node will
+        load that file.
 
 Node will process the paths in the order they appear in `module.paths` and return the first
 match.
@@ -745,7 +745,7 @@ jcouball_node_demo $
 The version in the `package.json` file is still `1.0.0`. In order to publish a
 different version, we need to update the `version` property.
 
-What should the new version be? Keeping in mind [Semantic Versioning](semantic-versioning),
+What should the new version be? Keeping in mind [Semantic Versioning](#semantic-versioning),
 the major version should not be updated since there are no backward
 incompatible changes. Since we ARE adding a new feature we should increment
 the minor version.

--- a/docs/javascript/complete_node_js/04_express.md
+++ b/docs/javascript/complete_node_js/04_express.md
@@ -5,7 +5,7 @@
 This chapter will introduce the [express npm module](https://www.npmjs.com/package/express)
 for building scalable web applications.
 
-Recall that in [the HTTP module introduction](../02_node_module_system/#http-module),
+Recall that in [the HTTP module introduction](02_node_module_system.md/#http-module),
 we had this code to implement a simple web app that implemented responses for
 `/` and `/friends`:
 
@@ -144,7 +144,7 @@ const app = express();
 
  app.get('/', (req, res) => {
 
-  
+
  });
 
 ```

--- a/docs/music_theory.md
+++ b/docs/music_theory.md
@@ -44,33 +44,33 @@ For example C to F# is a 4th but is not a perfect 4th as F# is not in C major sc
 #### major
 
 * There are four intervals that are called major intervals:
-  * major 2nd, major 3rd, major 6th, and major 7th
+    * major 2nd, major 3rd, major 6th, and major 7th
 * If the upper note of an interval is in the major scale of the lower note (and it’s
   not a 4th, 5th or 8ve) then it will be a major interval.
 
 * augmented
-  * An interval becomes augmented when we extend a major or perfect interval by one
-    semitone (half step) without changing the letter name.
-  * For example, given a major 2nd like F to G, change the G to G# to make an augmented
-    2nd.
-  * For example, given a perfect 5th like F to C, change the C to C# to make an
-    augmented 5th.
+    * An interval becomes augmented when we extend a major or perfect interval by one
+        semitone (half step) without changing the letter name.
+    * For example, given a major 2nd like F to G, change the G to G# to make an augmented
+        2nd.
+    * For example, given a perfect 5th like F to C, change the C to C# to make an
+        augmented 5th.
 
 * minor
-  * Any major interval made smaller by one semitone is a minor interval
-  * For example, if we took C to E which is a major 3rd and flattened the E to make it
-    an Eb, it now becomes a minor 3rd.
-  * Because there are only four major intervals there are also only four minor intervals:
-  * minor 2nd, minor 3rd, minor 6th, minor 7th
+    * Any major interval made smaller by one semitone is a minor interval
+    * For example, if we took C to E which is a major 3rd and flattened the E to make it
+        an Eb, it now becomes a minor 3rd.
+    * Because there are only four major intervals there are also only four minor intervals:
+    * minor 2nd, minor 3rd, minor 6th, minor 7th
 
 * diminished
-  * Flatten any of the three perfect intervals (the 4th, 5th or 8ve) or any minor
-    interval (minor 2nd, minor 3rd, minor 6th, or minor 7th) by a semitone, to make a
-    diminished interval.
-  * For example, given A and D which is a perfect 4th, flatten the D to Db to make it a
-    diminished 4th.
-  * For example, given E and D which is a minor 7th, flatten D to Db to make it a
-    diminished 7th.
+    * Flatten any of the three perfect intervals (the 4th, 5th or 8ve) or any minor
+        interval (minor 2nd, minor 3rd, minor 6th, or minor 7th) by a semitone, to make a
+        diminished interval.
+    * For example, given A and D which is a perfect 4th, flatten the D to Db to make it a
+        diminished 4th.
+    * For example, given E and D which is a minor 7th, flatten D to Db to make it a
+        diminished 7th.
 
 ### Interval Chart
 

--- a/docs/ruby/subprocesses.md
+++ b/docs/ruby/subprocesses.md
@@ -730,32 +730,32 @@ available system resources.
 See [Process.setrlimit](https://ruby-doc.org/core/Process.html#method-c-setrlimit)
 
 * Process.spawn rlimit options sets these limits
-  * limit_cpu # seconds of CPU time the scipt can use
+    * limit_cpu # seconds of CPU time the script can use
 
-  * rlimit_as # sets bound (in bytes) for address space made available to program
+    * rlimit_as # sets bound (in bytes) for address space made available to program
 
-  * Files open at a time, number of processes, etc.
+    * Files open at a time, number of processes, etc.
 
-  * Pay attention to the platform compatibility information listed for each
+    * Pay attention to the platform compatibility information listed for each
 
 * There is an option to set soft limits and hard limits
-  * Hard limits effects are both sudden and final usually resulting in the subprocess
-    being terminated
-  * If just one limit number is given, it is considered a hard limit:
-    * :limit_cpu => 2
-  * Soft limits raise a signal in the subprocess when the soft limit is hit (they can
-    be thought of as a warning to the subprocess):
-    * A hard limit needs to be specified along with the hard limit, the first number
-      is the soft limit and the second number is the hard limit:
-      * :limit_cpu = [1, 2]
-  * Example:
+    * Hard limits effects are both sudden and final usually resulting in the subprocess
+        being terminated
+    * If just one limit number is given, it is considered a hard limit:
+        * :limit_cpu => 2
+    * Soft limits raise a signal in the subprocess when the soft limit is hit (they can
+        be thought of as a warning to the subprocess):
+        * A hard limit needs to be specified along with the hard limit, the first number
+        is the soft limit and the second number is the hard limit:
+        * :limit_cpu = [1, 2]
+    * Example:
 
-      ```ruby
-      trap("XCPU") do
-        puts "Received SIGXCPU, shutting down"
-        exit
-      end
-      ```
+        ```ruby
+        trap("XCPU") do
+            puts "Received SIGXCPU, shutting down"
+            exit
+        end
+        ```
 
 ## Open Pipe
 

--- a/docs/ssl_tls.md
+++ b/docs/ssl_tls.md
@@ -7,20 +7,20 @@ to a public key using a digital signature. A certificate contains an identity
 is either signed by a Certificate Authority or is Self-Signed.
 
 * [Self-Signed Certificates](#self-signed-certificates)
-  * [Generate CA](#generate-ca)
-  * [Optional Stage: View Certificate's Content](#optional-stage-view-certificates-content)
-  * [Generate Certificate](#generate-certificate)
+    * [Generate CA](#generate-ca)
+    * [Optional Stage: View Certificate's Content](#optional-stage-view-certificates-content)
+    * [Generate Certificate](#generate-certificate)
 * [Certificate Formats](#certificate-formats)
-  * [Convert Certs](#convert-certs)
+    * [Convert Certs](#convert-certs)
 * [Verify Certificates](#verify-certificates)
 * [Install the CA Cert as a trusted root CA](#install-the-ca-cert-as-a-trusted-root-ca)
-  * [On Android](#on-android)
-  * [On Arch](#on-arch)
-  * [On Debian \& Derivatives](#on-debian--derivatives)
-  * [On Fedora](#on-fedora)
-  * [On iOS](#on-ios)
-  * [On macOS](#on-macos)
-  * [On Windows](#on-windows)
+    * [On Android](#on-android)
+    * [On Arch](#on-arch)
+    * [On Debian and Derivatives](#on-debian-and-derivatives)
+    * [On Fedora](#on-fedora)
+    * [On iOS](#on-ios)
+    * [On macOS](#on-macos)
+    * [On Windows](#on-windows)
 
 ## Self-Signed Certificates
 
@@ -133,7 +133,7 @@ update-ca-trust
 
 wiki page  [here](https://wiki.archlinux.org/title/User:Grawity/Adding_a_trusted_CA_certificate)
 
-### On Debian & Derivatives
+### On Debian and Derivatives
 
 * Move the CA certificate (`ca.pem`) into `/usr/local/share/ca-certificates/ca.crt`.
 * Update the Cert Store with:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,8 @@ markdown_extensions:
     - toc:
         permalink: true
         toc_depth: 3
+    - mdx_truly_sane_lists:
+        nested_indent: 4
 
 plugins:
     - search
@@ -74,7 +76,6 @@ nav:
     - Getting Started on Prompt Engineering: ai/getting_started_on_prompt_engineering.md
     - Prompt Engineering Best Practices: ai/prompt_engineering_best_practices.md
     - Prompt Engineering for Improved Performance: ai/prompt_engineering_for_improved_performance.md
-
 
   - Git / GitHub:
     - Git Tips: git/git.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ mkdocs
 pymdown-extensions
 mkdocs-material ~= 9.0, >= 9.0.3
 markdown-include
+mdx_truly_sane_lists
+


### PR DESCRIPTION
Make the tab size 4 spaces instead of 2 to be more conformant with all markdown processors.

* Fix tab size for markdown files in vs code config
* Fix tab size in the markdown lint config
* Fix instances of 2 space indent to 4 spaces